### PR TITLE
Notify TrackMap's participants about activating live tracking

### DIFF
--- a/app/src/main/java/com/handysparksoft/trackmap/core/di/UseCaseModule.kt
+++ b/app/src/main/java/com/handysparksoft/trackmap/core/di/UseCaseModule.kt
@@ -67,4 +67,12 @@ class UseCaseModule {
     @Provides
     fun stopLiveTrackingUseCaseProvider(trackMapRepository: TrackMapRepository) =
         StopLiveTrackingUseCase(trackMapRepository)
+
+    @Provides
+    fun sendPushNotificationUseCaseProvider(trackMapRepository: TrackMapRepository) =
+        SendPushNotificationUseCase(trackMapRepository)
+
+    @Provides
+    fun getTrackMapByIdUseCaseProvider(trackMapRepository: TrackMapRepository) =
+        GetTrackMapByIdUseCase(trackMapRepository)
 }

--- a/app/src/main/java/com/handysparksoft/trackmap/core/di/ViewModelModule.kt
+++ b/app/src/main/java/com/handysparksoft/trackmap/core/di/ViewModelModule.kt
@@ -1,10 +1,12 @@
 package com.handysparksoft.trackmap.core.di
 
+import com.handysparksoft.trackmap.core.platform.LocationForegroundServiceHandler
 import com.handysparksoft.trackmap.core.platform.Prefs
 import com.handysparksoft.trackmap.core.platform.UserHandler
 import com.handysparksoft.trackmap.features.create.CreateViewModelFactory
 import com.handysparksoft.trackmap.features.entries.EntriesViewModelFactory
 import com.handysparksoft.trackmap.features.join.JoinViewModelFactory
+import com.handysparksoft.trackmap.features.notification.PushNotificationHandler
 import com.handysparksoft.trackmap.features.participants.ParticipantsViewModelFactory
 import com.handysparksoft.trackmap.features.profile.ProfileViewModelFactory
 import com.handysparksoft.trackmap.features.trackmap.TrackMapViewModelFactory
@@ -24,7 +26,10 @@ class ViewModelModule {
         favoriteTrackMapUseCase: FavoriteTrackMapUseCase,
         updateUserBatteryLevelUseCase: UpdateUserBatteryLevelUseCase,
         userHandler: UserHandler,
-        prefs: Prefs
+        prefs: Prefs,
+        getTrackMapByIdUseCase: GetTrackMapByIdUseCase,
+        pushNotificationHandler: PushNotificationHandler,
+        locationForegroundServiceHandler: LocationForegroundServiceHandler
     ) =
         EntriesViewModelFactory(
             getTrackMapsUseCase,
@@ -34,7 +39,10 @@ class ViewModelModule {
             favoriteTrackMapUseCase,
             updateUserBatteryLevelUseCase,
             userHandler,
-            prefs
+            prefs,
+            getTrackMapByIdUseCase,
+            pushNotificationHandler,
+            locationForegroundServiceHandler
         )
 
     @Provides
@@ -53,14 +61,14 @@ class ViewModelModule {
     fun joinViewModelFactoryProvider(
         joinTrackMapUseCase: JoinTrackMapUseCase,
         saveUserTrackMapUseCase: SaveUserTrackMapUseCase,
-        getUserAccessDataUseCase: GetUserAccessDataUseCase,
-        userHandler: UserHandler
+        userHandler: UserHandler,
+        pushNotificationHandler: PushNotificationHandler
     ) =
         JoinViewModelFactory(
             joinTrackMapUseCase,
             saveUserTrackMapUseCase,
-            getUserAccessDataUseCase,
-            userHandler
+            userHandler,
+            pushNotificationHandler
         )
 
     @Provides
@@ -70,7 +78,12 @@ class ViewModelModule {
         userHandler: UserHandler,
         prefs: Prefs,
     ) =
-        ProfileViewModelFactory(getUuserProfileDataUseCase, updateUserProfileUseCase, userHandler, prefs)
+        ProfileViewModelFactory(
+            getUuserProfileDataUseCase,
+            updateUserProfileUseCase,
+            userHandler,
+            prefs
+        )
 
     @Provides
     fun participantsViewModelFactoryProvider(

--- a/app/src/main/java/com/handysparksoft/trackmap/core/platform/FirebaseTracking.kt
+++ b/app/src/main/java/com/handysparksoft/trackmap/core/platform/FirebaseTracking.kt
@@ -53,6 +53,7 @@ sealed class TrackEvent {
 
     object GoActionClick : TrackEvent()
     object LeaveActionClick : TrackEvent()
+    object PingActionClick : TrackEvent()
     object ShareActionClick : TrackEvent()
     object ShowParticipantsActionClick : TrackEvent()
     object FavoriteActionClick : TrackEvent()

--- a/app/src/main/java/com/handysparksoft/trackmap/core/platform/LocationForegroundService.kt
+++ b/app/src/main/java/com/handysparksoft/trackmap/core/platform/LocationForegroundService.kt
@@ -86,7 +86,7 @@ class LocationForegroundService : Service(), Scope by Scope.Impl() {
     override fun onDestroy() {
         stopRequestLocationUpdates()
         stopRequestGPSLocationUpdates()
-        locationForegroundServiceHandler.clearAllLiveTracking()
+        locationForegroundServiceHandler.onDestroy()
         destroyScope()
 
         super.onDestroy()

--- a/app/src/main/java/com/handysparksoft/trackmap/core/platform/LocationForegroundServiceHandler.kt
+++ b/app/src/main/java/com/handysparksoft/trackmap/core/platform/LocationForegroundServiceHandler.kt
@@ -28,6 +28,8 @@ class LocationForegroundServiceHandler @Inject constructor(
 
     val liveTrackingMapIds = mutableSetOf<String>()
 
+    var onDestroyListener: (() -> Unit)? = null
+
     init {
         initScope()
     }
@@ -125,5 +127,10 @@ class LocationForegroundServiceHandler @Inject constructor(
                 activity.startService(serviceIntent)
             }
         }
+    }
+
+    fun onDestroy() {
+        clearAllLiveTracking()
+        onDestroyListener?.invoke()
     }
 }

--- a/app/src/main/java/com/handysparksoft/trackmap/features/create/CreateFragment.kt
+++ b/app/src/main/java/com/handysparksoft/trackmap/features/create/CreateFragment.kt
@@ -13,6 +13,9 @@ import com.handysparksoft.trackmap.R
 import com.handysparksoft.trackmap.core.extension.SnackbarType
 import com.handysparksoft.trackmap.core.extension.app
 import com.handysparksoft.trackmap.core.extension.snackbar
+import com.handysparksoft.trackmap.core.platform.TrackEvent
+import com.handysparksoft.trackmap.core.platform.TrackEvent.CreateActionClick
+import com.handysparksoft.trackmap.core.platform.track
 import com.handysparksoft.trackmap.core.platform.viewbinding.FragmentViewBindingHolder
 import com.handysparksoft.trackmap.databinding.FragmentCreateBinding
 
@@ -66,6 +69,7 @@ class CreateFragment : Fragment() {
                     )
                 }
             }
+            CreateActionClick.track()
         }
     }
 

--- a/app/src/main/java/com/handysparksoft/trackmap/features/entries/EntriesAdapter.kt
+++ b/app/src/main/java/com/handysparksoft/trackmap/features/entries/EntriesAdapter.kt
@@ -17,6 +17,7 @@ class EntriesAdapter(
     private val userSession: String,
     private val onGoListener: (trackMap: TrackMap) -> Unit,
     private val onLeaveListener: (trackMap: TrackMap) -> Unit,
+    private val onPingParticipantsListener: (trackMap: TrackMap) -> Unit,
     private val onFavoriteListener: (trackMap: TrackMap, favorite: Boolean) -> Unit,
     private val onLiveTrackingListener: (trackMap: TrackMap, startTracking: Boolean) -> Unit,
     private val onShareListener: (trackMap: TrackMap) -> Unit,
@@ -40,7 +41,6 @@ class EntriesAdapter(
 
     inner class ViewHolder(private val itemBinding: ItemTrackmapBinding) :
         RecyclerView.ViewHolder(itemBinding.root) {
-        //@Suppress("DEPRECATION")
         fun bind(trackMap: TrackMap) {
             if (trackMap.participantIds != null) {
                 val ownerName = trackMap.ownerName ?: trackMap.ownerId
@@ -56,7 +56,7 @@ class EntriesAdapter(
 
                 setLiveTrackingState(
                     itemBinding.trackMapLiveTrackingButton,
-                    trackMap.liveParticipantIds?.contains(userSession) == true
+                    isLiveTrackingActive(trackMap)
                 )
 
                 // Bind listeners
@@ -68,6 +68,9 @@ class EntriesAdapter(
                 }
                 itemBinding.trackMapLeaveImageButton.setOnClickListener {
                     onLeaveListener.invoke(trackMap)
+                }
+                itemBinding.trackMapPingImageButton.setOnClickListener {
+                    onPingParticipantsListener.invoke(trackMap)
                 }
                 itemBinding.trackMapFavoriteImageButton.setOnClickListener {
                     val selected = it.tag == true
@@ -86,6 +89,9 @@ class EntriesAdapter(
                 }
             }
         }
+
+        private fun isLiveTrackingActive(trackMap: TrackMap) =
+            trackMap.liveParticipantIds?.contains(userSession) == true
 
         private fun getCreationText(
             view: View,

--- a/app/src/main/java/com/handysparksoft/trackmap/features/join/JoinFragment.kt
+++ b/app/src/main/java/com/handysparksoft/trackmap/features/join/JoinFragment.kt
@@ -18,6 +18,9 @@ import com.handysparksoft.trackmap.core.extension.app
 import com.handysparksoft.trackmap.core.extension.hideKeyBoard
 import com.handysparksoft.trackmap.core.extension.snackbar
 import com.handysparksoft.trackmap.core.platform.Event
+import com.handysparksoft.trackmap.core.platform.TrackEvent
+import com.handysparksoft.trackmap.core.platform.TrackEvent.JoinActionClick
+import com.handysparksoft.trackmap.core.platform.track
 import com.handysparksoft.trackmap.databinding.FragmentJoinBinding
 
 
@@ -61,6 +64,7 @@ class JoinFragment : Fragment() {
                 }
             }
             activity?.hideKeyBoard()
+            JoinActionClick.track()
         }
     }
 

--- a/app/src/main/java/com/handysparksoft/trackmap/features/notification/PushNotificationHandler.kt
+++ b/app/src/main/java/com/handysparksoft/trackmap/features/notification/PushNotificationHandler.kt
@@ -1,0 +1,119 @@
+package com.handysparksoft.trackmap.features.notification
+
+import android.content.Context
+import com.handysparksoft.data.Result
+import com.handysparksoft.domain.model.NotificationData
+import com.handysparksoft.domain.model.PushNotification
+import com.handysparksoft.domain.model.TrackMap
+import com.handysparksoft.trackmap.R
+import com.handysparksoft.trackmap.core.platform.Scope
+import com.handysparksoft.trackmap.core.platform.UserHandler
+import com.handysparksoft.usecases.GetUserAccessDataUseCase
+import com.handysparksoft.usecases.SendPushNotificationUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class PushNotificationHandler @Inject constructor(
+    private val sendPushNotificationUseCase: SendPushNotificationUseCase,
+    private val getUserAccessDataUseCase: GetUserAccessDataUseCase,
+    private val userHandler: UserHandler
+) : Scope by Scope.Impl() {
+
+    init {
+        initScope()
+    }
+
+    fun destroy() {
+        destroyScope()
+    }
+
+    fun notifyNewParticipantHasJoin(
+        context: Context,
+        userId: String,
+        trackMap: TrackMap
+    ) {
+        launch(Dispatchers.IO) {
+            val usersIds = trackMap.participantIds.filter { it != userId }
+            val tokens = getUserTokens(usersIds)
+
+            if (tokens.isNotEmpty()) {
+                val participant = userHandler.getUserNickname()
+                    ?: context.getString(R.string.push_notification_generic_user_joined_message)
+
+                val notificationData = NotificationData(
+                    title = context.getString(R.string.push_notification_user_joined_title),
+                    body = context.getString(
+                        R.string.push_notification_user_joined_message,
+                        participant,
+                        trackMap.name
+                    )
+                )
+                val pushNotification = PushNotification(
+                    to = null,
+                    registration_ids = tokens,
+                    notification = notificationData
+                )
+                val authorizationToken = context.getString(R.string.push_notification_server_key)
+
+                sendPushNotificationUseCase.execute(
+                    authorizationToken,
+                    pushNotification
+                )
+            }
+        }
+    }
+
+    fun pingParticipants(
+        context: Context,
+        userId: String,
+        trackMap: TrackMap
+    ) {
+        launch(Dispatchers.Main) {
+            val usersIds = trackMap.participantIds.filter { it != userId }
+            val tokens = getUserTokens(usersIds)
+
+            if (tokens.isNotEmpty()) {
+                val participant = userHandler.getUserNickname() ?: userHandler.getUserFullName()
+
+                val notificationData = NotificationData(
+                    title = context.getString(
+                        R.string.push_notification_ping_user_being_tracked_title,
+                        trackMap.name
+                    ),
+                    body = context.getString(
+                        R.string.push_notification_ping_user_being_tracked_participant,
+                        participant
+                    )
+                )
+                val pushNotification = PushNotification(
+                    to = null,
+                    registration_ids = tokens,
+                    notification = notificationData
+                )
+                val authorizationToken = context.getString(R.string.push_notification_server_key)
+
+                sendPushNotificationUseCase.execute(
+                    authorizationToken,
+                    pushNotification
+                )
+            }
+        }
+    }
+
+    private suspend fun getUserTokens(usersIds: List<String>): List<String> {
+        val tokens = mutableListOf<String>()
+        val awaitAll = usersIds.map {
+            async { getUserAccessDataUseCase.execute(it) }
+        }.awaitAll()
+
+        awaitAll.forEach { result ->
+            if (result is Result.Success) {
+                result.data.userToken?.let { tokens.add(it) }
+            }
+        }
+        return tokens
+    }
+}

--- a/app/src/main/java/com/handysparksoft/trackmap/features/trackmap/TrackMapActivity.kt
+++ b/app/src/main/java/com/handysparksoft/trackmap/features/trackmap/TrackMapActivity.kt
@@ -35,7 +35,6 @@ import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.ValueEventListener
 import com.google.gson.Gson
 import com.handysparksoft.domain.model.ParticipantLocation
-import com.handysparksoft.domain.model.ParticipantLocationSnapshot
 import com.handysparksoft.domain.model.TrackMap
 import com.handysparksoft.domain.model.UserMarkerData
 import com.handysparksoft.trackmap.BuildConfig

--- a/app/src/main/res/drawable/ic_notification_ping.xml
+++ b/app/src/main/res/drawable/ic_notification_ping.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7.58,4.08L6.15,2.65C3.75,4.48 2.17,7.3 2.03,10.5h2c0.15,-2.65 1.51,-4.97 3.55,-6.42zM19.97,10.5h2c-0.15,-3.2 -1.73,-6.02 -4.12,-7.85l-1.42,1.43c2.02,1.45 3.39,3.77 3.54,6.42zM18,11c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2v-5zM12,22c0.14,0 0.27,-0.01 0.4,-0.04 0.65,-0.14 1.18,-0.58 1.44,-1.18 0.1,-0.24 0.15,-0.5 0.15,-0.78h-4c0.01,1.1 0.9,2 2.01,2z" />
+</vector>

--- a/app/src/main/res/layout/item_trackmap.xml
+++ b/app/src/main/res/layout/item_trackmap.xml
@@ -46,6 +46,18 @@
         app:layout_constraintTop_toBottomOf="@+id/creationDateTextView" />
 
     <ImageButton
+        android:id="@+id/trackMapPingImageButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/title_share"
+        android:padding="8dp"
+        android:src="@drawable/ic_notification_ping"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/trackMapLiveTrackingButton"
+        app:layout_constraintTop_toBottomOf="@+id/creationDateTextView" />
+
+    <ImageButton
         android:id="@+id/trackMapLeaveImageButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -54,7 +66,7 @@
         android:padding="8dp"
         android:src="@drawable/ic_delete"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/trackMapLiveTrackingButton"
+        app:layout_constraintEnd_toStartOf="@id/trackMapPingImageButton"
         app:layout_constraintTop_toBottomOf="@+id/creationDateTextView" />
 
     <TextView

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -143,4 +143,11 @@
     <string name="participants_content_description">Lista de participantes</string>
     <string name="participants_image_description">Imagen del participant</string>
     <string name="participants_owner_tag">Creador del grupo</string>
+
+    <string name="ping_participants_question">Vas a notificar a los participantes de \"%1$s\" de que estás compartiendo tu ubicación en tiempo real</string>
+    <string name="ping_participants_positive_button">Proceder</string>
+    <string name="ping_participants_non_live_tracking_active">Activa primero el tracking en tiempo real para notificar al resto de participantes</string>
+
+    <string name="push_notification_ping_user_being_tracked_title">%1$s</string>
+    <string name="push_notification_ping_user_being_tracked_participant">%1$s\n📌 Compartiendo ubiciación en tiempo real</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,4 +143,11 @@
     <string name="participants_content_description">Participant list</string>
     <string name="participants_image_description">Participant image</string>
     <string name="participants_owner_tag">Group\'s Owner</string>
+
+    <string name="ping_participants_question">You are going to ping all participants of \"%1$s\" to let them know you have activated your live tracking</string>
+    <string name="ping_participants_positive_button">Proceed</string>
+    <string name="ping_participants_non_live_tracking_active">First activate the live tracking to notify other participants</string>
+
+    <string name="push_notification_ping_user_being_tracked_title">%1$s</string>
+    <string name="push_notification_ping_user_being_tracked_participant">%1$s\n📌 Sharing live tracking</string>
 </resources>

--- a/domain/src/main/java/com/handysparksoft/domain/model/UserProfileData.kt
+++ b/domain/src/main/java/com/handysparksoft/domain/model/UserProfileData.kt
@@ -2,7 +2,7 @@ package com.handysparksoft.domain.model
 
 import java.io.Serializable
 
-data class UserProfileData(
+data class  UserProfileData(
     val userId: String,
     val nickname: String?,
     val fullName: String?,

--- a/usecases/src/main/java/com/handysparksoft/usecases/GetTrackMapByIdUseCase.kt
+++ b/usecases/src/main/java/com/handysparksoft/usecases/GetTrackMapByIdUseCase.kt
@@ -1,0 +1,15 @@
+package com.handysparksoft.usecases
+
+import com.handysparksoft.data.Result
+import com.handysparksoft.data.repository.TrackMapRepository
+import com.handysparksoft.domain.model.TrackMap
+
+class GetTrackMapByIdUseCase(private val trackMapRepository: TrackMapRepository) {
+    suspend fun execute(trackMapId: String): TrackMap? {
+        val trackMap = trackMapRepository.getTrackMapById(trackMapId)
+        if (trackMap is Result.Success && trackMap.data != null) {
+            return trackMap.data
+        }
+        return null
+    }
+}

--- a/usecases/src/main/java/com/handysparksoft/usecases/JoinTrackMapUseCase.kt
+++ b/usecases/src/main/java/com/handysparksoft/usecases/JoinTrackMapUseCase.kt
@@ -33,8 +33,4 @@ class JoinTrackMapUseCase(private val trackMapRepository: TrackMapRepository) {
         }
         return null
     }
-
-    suspend fun executeSendPushNotification(authorization: String, pushNotification: PushNotification) {
-        trackMapRepository.sendPushNotification(authorization,  pushNotification)
-    }
 }

--- a/usecases/src/main/java/com/handysparksoft/usecases/SendPushNotificationUseCase.kt
+++ b/usecases/src/main/java/com/handysparksoft/usecases/SendPushNotificationUseCase.kt
@@ -1,0 +1,10 @@
+package com.handysparksoft.usecases
+
+import com.handysparksoft.data.repository.TrackMapRepository
+import com.handysparksoft.domain.model.PushNotification
+
+class SendPushNotificationUseCase(private val trackMapRepository: TrackMapRepository) {
+    suspend fun execute(authorization: String, pushNotification: PushNotification) {
+        trackMapRepository.sendPushNotification(authorization, pushNotification)
+    }
+}


### PR DESCRIPTION

## Overview 📋
Notify all TrackMap's participants that the user has the live tracking active

### What does this pull request do? ⚙️
Adds new action (the bell one 🔔) on the TrackMap item to send a Push notification (📌) to all participants of a TrackMap that the user has the live tracking active. This way the user is claiming other participants to join him on the activity.

To send the push notification, first, the live tracking should be activated otherwise a snackbar pops out and informs about activating live tracking first.

### Screenshots 📸
<table >
	<tbody>
		<tr>
			<td>
<img src="https://user-images.githubusercontent.com/11421976/106399701-8ba97d00-641a-11eb-91a8-b9520126090c.png" width=300px>
			</td>
			<td>
<img src="https://user-images.githubusercontent.com/11421976/106399705-8f3d0400-641a-11eb-83c6-09eed5332f44.png" width=300px>
			</td>
			<td>
<img src="https://user-images.githubusercontent.com/11421976/106399706-8fd59a80-641a-11eb-8dbc-fe9756f74fe3.png" width=300px>
			</td>
		</tr>
	</tbody>
</table>

### Where should the reviewer start? 🔬
Entries activity -> activate live tracking on any TrackMap and then -> click the bell button

### Full review reviewers 🧑🏻‍💻
@davidasensio 
<br />
